### PR TITLE
Change location of CYBORG data

### DIFF
--- a/Supybot-plugins-20060723/CyborgName/plugin.py
+++ b/Supybot-plugins-20060723/CyborgName/plugin.py
@@ -45,7 +45,7 @@ class CyborgName(callbacks.Plugin):
         except utils.web.Error, e:
             irc.error(str(e))
 
-    _cyborgRe = re.compile(r'<p class="mediumheader">(.*?)</p>', re.I)
+    _cyborgRe = re.compile(r'<div class="mediumheader">(.*?)</div>', re.I)
     def cyborg(self, irc, msg, args, name):
         """[<name>]
 


### PR DESCRIPTION
Used to be in a <p> tag -- now appears to be in a <div> tag, still with the `class="mediumheader"` attribute.
