### PR TITLE
registry.String needs a string for default value

### DIFF
--- a/plugins/Cast/config.py
+++ b/plugins/Cast/config.py
@@ -45,6 +45,6 @@ Cast = conf.registerPlugin('Cast')
 # conf.registerGlobalValue(Cast, 'someConfigVariableName',
 #     registry.Boolean(False, """Help for someConfigVariableName."""))
 
-conf.registerGlobalValue(Cast, 'FreebaseAPIKey', registry.String(False, """Freebase API Key"""))
+conf.registerGlobalValue(Cast, 'FreebaseAPIKey', registry.String("", """Freebase API Key"""))
 
 # vim:set shiftwidth=4 tabstop=4 expandtab textwidth=79:


### PR DESCRIPTION
(This is logging errors every hour, although it doesn't seem to have any other noticeable effect on the bot's functions)