### PR TITLE
Also decode tea name

### DIFF
--- a/edsu-plugins/Assorted/plugin.py
+++ b/edsu-plugins/Assorted/plugin.py
@@ -1086,6 +1086,7 @@ class Assorted(callbacks.Privmsg):
                 break
         tea = teas[randint(0, len(teas)-1)]
         tea_name = tea.string.encode('utf-8')
+        tea_name = tea_name.decode('utf-8')
         tea_url = "http://ratetea.com" + tea['href']
         if len(args) > 0:
             nick = ' '.join(args)


### PR DESCRIPTION
supybot was still breaking with the top10 tea that contained a TM in the
name. Add a decode to fix that.

Signed-off-by: Ben Shum <bshum@biblio.org>